### PR TITLE
Updated Deploy Settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Example in Node.js
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/TillMobile/till-node-example)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/RobertoMachorro/till-node-example)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Example in Node.js
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/RobertoMachorro/till-node-example)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/TillMobile/till-node-example)

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "Free"
+      "size": "Eco"
     } 
   },
   "image": "heroku/nodejs",

--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
   "image": "heroku/nodejs",
   "addons": [
     {
-      "plan": "till:free"
+      "plan": "till:whirl"
     },
     {
       "plan": "pusher"


### PR DESCRIPTION
Current settings are outdated, neither Heroku nor Till support Free tiers anymore.
While Till won't fail installing (Heroku doesn't), it simply won't send messages.
The configuration update was tested in Heroku on 4/21/2023 successfully.